### PR TITLE
Allow raw url for logo

### DIFF
--- a/src/harvest.ts
+++ b/src/harvest.ts
@@ -219,8 +219,13 @@ async function extractLogoImageSrc(url: string): Promise<string> {
 async function deriveLogo(config: any, query: BookQuery): Promise<string> {
   let logo: string;
   if ("logo" in config) {
-    const relLogo = query.toc_path.replace("_toc.yml", config.logo);
-    logo = await makeDownloadUrl(query.code_url, query.release, relLogo);
+    // Check if logo is already an absolute URL
+    if (config.logo.startsWith("http://") || config.logo.startsWith("https://")) {
+      logo = config.logo;
+    } else {
+      const relLogo = query.toc_path.replace("_toc.yml", config.logo);
+      logo = await makeDownloadUrl(query.code_url, query.release, relLogo);
+    }
   } else if ("html_static_path" in config.sphinx.config) {
     const relLogo = config.sphinx.config.html_theme_options.logo.image_light;
     const staticPath = config.sphinx.config.html_static_path[0];


### PR DESCRIPTION
The logo scraping logic incorrectly treated all `logo` entries in `_config.yml` as relative paths, causing issues when books reference externally hosted logos. For example, the MUDE book uses `https://files.mude.citg.tudelft.nl/MUDE_Logo-small.png`, but the code attempted to construct: https://raw.githubusercontent.com/TUDelft-MUDE/book/refs/heads/2024/book/https:/files.mude.citg.tudelft.nl/MUDE_Logo-small.png

Added a check in the `deriveLogo` function to detect if the `logo` entry starts with `http://` or `https://`. When detected, the URL is used directly instead of being treated as a relative path.